### PR TITLE
:tada:  `Portfolio` uses default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,7 @@ risk_config = RiskConfig(
 )
 
 # Initialize portfolio
-initial_portfolio = Portfolio(
-    starting_date=datetime(2023, 1, 1),
-    starting_asset=0,
-    starting_currency=10_000,
-)
+initial_portfolio = Portfolio(starting_date=datetime(2023, 1, 1))
 
 # Load market data (you'll need to implement this for your data source)
 fluctuations: Fluctuations = load_your_market_data(...)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Here's a simple example of defining trading signals and running a backtest:
 from datetime import datetime
 
 from ptahlmud.backtesting.backtest import RiskConfig, process_signals
-from ptahlmud.backtesting.portfolio import Portfolio
 from ptahlmud.entities.fluctuations import Fluctuations
 from ptahlmud.types.signal import Signal, Side, Action
 
@@ -45,23 +44,19 @@ risk_config = RiskConfig(
     stop_loss=0.03,    # Cut losses at 3% price decrease
 )
 
-# Initialize portfolio
-initial_portfolio = Portfolio(starting_date=datetime(2023, 1, 1))
-
 # Load market data (you'll need to implement this for your data source)
 fluctuations: Fluctuations = load_your_market_data(...)
 
 # Run the backtest
-trades, final_portfolio = process_signals(
+trades = process_signals(
     signals=signals,
     risk_config=risk_config,
     fluctuations=fluctuations,
-    initial_portfolio=initial_portfolio,
 )
 
 # Analyze results
 print(f"Number of trades : {len(trades)}")
-print(f"Final capital : {final_portfolio.get_available_capital_at(datetime(2023, 3, 1))}")
+print(f"Total profit : {sum([trade.total_profit for trade in trades])}")
 print(f"Win rate : {sum([1 for trade in trades if trade.total_profit > 0]) / len(trades)}")
 ```
 
@@ -104,11 +99,10 @@ def moving_average_strategy(fluctuations, fast_period: int, slow_period: int) ->
     return signals
 
 signals = moving_average_strategy(market_date, fast_period=10, slow_period=30)
-trades, final_portfolio = process_signals(
+trades = process_signals(
     signals=signals,
     fluctuations=market_date,
     risk_config=risk_config,
-    initial_portfolio=initial_portfolio,
 )
 
 

--- a/ptahlmud/backtesting/backtest.py
+++ b/ptahlmud/backtesting/backtest.py
@@ -12,7 +12,6 @@ The core functionality is encapsulated in `process_signals()`, which transforms
 a sequence of raw trading signals into a list of executed trades and an updated portfolio.
 """
 
-from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -117,21 +116,19 @@ def process_signals(
     signals: list[Signal],
     risk_config: RiskConfig,
     fluctuations: Fluctuations,
-    initial_portfolio: Portfolio,
-) -> tuple[list[Trade], Portfolio]:
+) -> list[Trade]:
     """Process trading signals to generate trades and track portfolio changes.
 
     Args:
         signals: trading signals
         risk_config: risk management parameters
         fluctuations: market data
-        initial_portfolio: portfolio starting state
 
     Returns:
         executed trades as a list
         the portfolio after trading session
     """
-    portfolio = deepcopy(initial_portfolio)
+    portfolio = Portfolio(starting_date=fluctuations.candles[0].open_time)
     fluctuations_end_time = fluctuations.candles[-1].open_time
     trades: list[Trade] = []
     trade_size = Decimal(str(risk_config.size))
@@ -153,4 +150,4 @@ def process_signals(
         )
         trades.append(new_trade)
         portfolio.update_from_trade(new_trade)
-    return trades, portfolio
+    return trades

--- a/ptahlmud/backtesting/portfolio.py
+++ b/ptahlmud/backtesting/portfolio.py
@@ -120,26 +120,35 @@ def _find_date_position(date: datetime, date_collection: list[datetime]) -> int:
 class Portfolio:
     """Represent a trading portfolio over time.
 
-    The `Portfolio` class manages operations involving trades and tracks
+    The `Portfolio` class tracks operations involving trades and tracks
     the state of wealth (currency and asset volume) dynamically across time.
+    It always starts with an asset volume of 0 and a free currency amount of 100.
 
     Args:
         starting_date: the initial timestamp marking the portfolio's creation
-        starting_asset: initial volume of asset in the portfolio
-        starting_currency: initial amount of free capital in the portfolio
     """
 
     wealth_series: WealthSeries
 
-    def __init__(self, starting_date: datetime, starting_asset: float, starting_currency: float):
+    def __init__(self, starting_date: datetime):
         wealth_items = [
             WealthItem(
                 date=starting_date,
-                asset=Decimal(starting_asset),
-                currency=Decimal(starting_currency),
+                asset=self.default_asset_amount(),
+                currency=self.default_currency_amount(),
             )
         ]
         self.wealth_series = WealthSeries(items=wealth_items, entries=[])
+
+    @staticmethod
+    def default_currency_amount() -> Decimal:
+        """The amount of currency available at the start of the trading session."""
+        return Decimal(100)
+
+    @staticmethod
+    def default_asset_amount() -> Decimal:
+        """The amount of asset available at the start of the trading session."""
+        return Decimal(0)
 
     def _perform_entry(self, date: datetime, currency_amount: Decimal, asset_volume: Decimal) -> None:
         """Record market entry by investing a specified amount of currency."""

--- a/tests/backtesting/test_backtest.py
+++ b/tests/backtesting/test_backtest.py
@@ -113,23 +113,11 @@ def some_risk_config(draw) -> RiskConfig:
     )
 
 
-@composite
-def some_portfolio(draw) -> Portfolio:
-    return Portfolio(
-        starting_date=datetime(2020, 1, 1),
-        starting_asset=draw(some.integers(min_value=0, max_value=1_000_000)),
-        starting_currency=draw(some.integers(min_value=0, max_value=1_000_000)),
-    )
-
-
 @given(
     some_signals(),
     some_risk_config(),
-    some_portfolio(),
 )
-def test_process_signals_trades_property(
-    request, signals: list[Signal], risk_config: RiskConfig, initial_portfolio: Portfolio
-):
+def test_process_signals_trades_property(request, signals: list[Signal], risk_config: RiskConfig):
     """Check that trades are correctly generated from signals."""
     # pytest user-defined fixtures and hypothesis are not compatible, access `random_fluctuations` manually
     fluctuations = request.getfixturevalue("random_fluctuations")
@@ -137,7 +125,7 @@ def test_process_signals_trades_property(
         signals=signals,
         risk_config=risk_config,
         fluctuations=fluctuations,
-        initial_portfolio=initial_portfolio,
+        initial_portfolio=Portfolio(starting_date=datetime(2020, 1, 1)),
     )
 
     # we don't trade when there is no capital, so we can have less trades than entry signals.
@@ -149,14 +137,12 @@ def test_process_signals_trades_property(
 @given(
     some_signals(),
     some_risk_config(),
-    some_portfolio(),
 )
-def test_process_signals_portfolio_property(
-    request, signals: list[Signal], risk_config: RiskConfig, initial_portfolio: Portfolio
-):
+def test_process_signals_portfolio_property(request, signals: list[Signal], risk_config: RiskConfig):
     """Check the portfolio state after signals are processed."""
     # pytest user-defined fixtures and hypothesis are not compatible, access `random_fluctuations` manually
     fluctuations = request.getfixturevalue("random_fluctuations")
+    initial_portfolio = Portfolio(starting_date=datetime(2020, 1, 1))
     trades, portfolio = process_signals(
         signals=signals, risk_config=risk_config, fluctuations=fluctuations, initial_portfolio=initial_portfolio
     )


### PR DESCRIPTION
## Description

`Portfolio` now initializes with fixed values.

## Context

Giving starting values gives too much power on the user.
Moreover, having default values allows to recalculate entirely a portfolio from trades.
The `Portfolio` now becomes a detail of the backtest, can be recalculated from scratch using the trades.