### PR TITLE
:recycle:  Optimize fluctuations loading

### DIFF
--- a/ptahlmud/datastack/fluctuations.py
+++ b/ptahlmud/datastack/fluctuations.py
@@ -33,6 +33,11 @@ class Fluctuations:
 
         self.dataframe = dataframe
 
+    @classmethod
+    def empty(cls) -> "Fluctuations":
+        """Create an empty fluctuations."""
+        return cls(dataframe=pd.DataFrame(columns=["open_time", "close_time", "open", "high", "low", "close"]))
+
     @property
     def size(self) -> int:
         """Return the total number of candles."""

--- a/ptahlmud/datastack/fluctuations_service.py
+++ b/ptahlmud/datastack/fluctuations_service.py
@@ -126,14 +126,7 @@ class FluctuationsService:
             self._repository.save(fluctuations, coin=config.coin, currency=config.currency)
 
 
-class CustomOperation(BaseModel):
-    """Define a custom operation on a `pandas.series`."""
-
-    column: str
-    function: Callable[[pd.Series], int | float]
-
-
-def _build_aggregation_function(custom_ops: list[CustomOperation]) -> Callable[[pd.DataFrame], pd.Series]:
+def _build_aggregation_function() -> Callable[[pd.DataFrame], pd.Series]:
     def custom_agg(group: pd.DataFrame) -> pd.Series:
         if len(group) == 0:
             return pd.Series()
@@ -152,7 +145,6 @@ def _build_aggregation_function(custom_ops: list[CustomOperation]) -> Callable[[
                 "low": group["low"].min(),
                 "close": group["close"].iloc[-1],
             }
-            | {operation.column: operation.function(group[operation.column]) for operation in custom_ops}
         )
 
     return custom_agg
@@ -162,7 +154,7 @@ def _convert_fluctuations_to_period(fluctuations: Fluctuations, period: Period) 
     """Convert fluctuations dataframe rows as a single one."""
     if fluctuations.size == 0:
         return fluctuations
-    custom_aggregation = _build_aggregation_function(custom_ops=[])
+    custom_aggregation = _build_aggregation_function()
 
     df = fluctuations.dataframe.copy()
     df_indexed = df.set_index(df["open_time"])

--- a/ptahlmud/datastack/fluctuations_service.py
+++ b/ptahlmud/datastack/fluctuations_service.py
@@ -138,15 +138,14 @@ def _build_aggregation_function(custom_ops: list[CustomOperation]) -> Callable[[
         if len(group) == 0:
             return pd.Series()
 
-        # Find indices of max and min values
         high_max_idx = group["high"].idxmax()
         low_min_idx = group["low"].idxmin()
 
         return pd.Series(
             {
                 "open_time": group["open_time"].iloc[0],
-                "high_time": high_max_idx,
-                "low_time": low_min_idx,
+                "high_time": group["close_time"][high_max_idx],
+                "low_time": group["close_time"][low_min_idx],
                 "close_time": group["close_time"].iloc[-1],
                 "open": group["open"].iloc[0],
                 "high": group["high"].max(),
@@ -177,7 +176,7 @@ def _convert_fluctuations_to_period(fluctuations: Fluctuations, period: Period) 
         .reset_index(drop=True)
     )
 
-    # the first or last candle may be incomplete when period is not a multiple of date range
+    # the first or last candle may be incomplete when the period is not a multiple of date range
     if (df_converted.iloc[-1]["open_time"] + period.to_timedelta()) != fluctuations.dataframe.iloc[-1]["close_time"]:
         df_converted = df_converted.iloc[:-1]
     return Fluctuations(dataframe=df_converted)

--- a/tests/datastack/test_fluctuations_service.py
+++ b/tests/datastack/test_fluctuations_service.py
@@ -5,7 +5,7 @@ import pytest
 from ptahlmud.datastack.clients.remote_client import RemoteClient
 from ptahlmud.datastack.fluctuations import Fluctuations
 from ptahlmud.datastack.fluctuations_repository import FilesMapper, FluctuationsRepository
-from ptahlmud.datastack.fluctuations_service import FluctuationsConfig, FluctuationsService
+from ptahlmud.datastack.fluctuations_service import FluctuationsService, FluctuationsSpecs
 from ptahlmud.datastack.testing.fluctuations import generate_fluctuations
 from ptahlmud.types import Period
 
@@ -32,7 +32,7 @@ def mocked_service(tmp_path):
 
 
 def test_service_request_is_empty(mocked_service):
-    config = FluctuationsConfig.model_validate(
+    config = FluctuationsSpecs.model_validate(
         {
             "coin": "FAKE",
             "currency": "NEWS",
@@ -46,7 +46,7 @@ def test_service_request_is_empty(mocked_service):
 
 
 def test_service_request_incomplete_data(mocked_service):
-    config = FluctuationsConfig.model_validate(
+    config = FluctuationsSpecs.model_validate(
         {
             "coin": "FAKE",
             "currency": "NEWS",
@@ -72,7 +72,7 @@ def test_service_request_incomplete_data(mocked_service):
 
 
 def test_service_fetch_data(mocked_service):
-    config = FluctuationsConfig.model_validate(
+    config = FluctuationsSpecs.model_validate(
         {
             "coin": "FAKE",
             "currency": "NEWS",
@@ -92,7 +92,7 @@ def test_service_fetch_data(mocked_service):
 
 
 def test_service_request_subset(mocked_service):
-    config = FluctuationsConfig.model_validate(
+    config = FluctuationsSpecs.model_validate(
         {
             "coin": "FAKE",
             "currency": "NEWS",
@@ -112,7 +112,7 @@ def test_service_request_subset(mocked_service):
 
 
 def test_service_request_and_convert_fluctuations(mocked_service):
-    config = FluctuationsConfig.model_validate(
+    config = FluctuationsSpecs.model_validate(
         {
             "coin": "FAKE",
             "currency": "NEWS",


### PR DESCRIPTION
## Description

The goal of this PR is to accelerate the request of fluctuations.

The database is today represented as files stored on the disk, each file contain daily fluctuations data.
The fluctuations can be loaded and converted by batch but we need precise date to form complete fluctuations of the desired period.
To do so I did use the LCM (the least common multiple) of the period and a 24-hours day to know the exact number of days to load from the database.