### PR TITLE
:recycle: fluctuations back to python class

### DIFF
--- a/ptahlmud/backtesting/operations.py
+++ b/ptahlmud/backtesting/operations.py
@@ -135,7 +135,7 @@ def calculate_trade(
     side: Side,
 ) -> Trade:
     """Calculate a trade."""
-    candle = fluctuations.get_candle_at(open_at)
+    candle = fluctuations.find_candle_containing(open_at)
     if open_at > candle.open_time:
         open_date = candle.close_time
         open_price = candle.close

--- a/ptahlmud/backtesting/operations.py
+++ b/ptahlmud/backtesting/operations.py
@@ -120,7 +120,7 @@ def _close_position(position: Position, fluctuations: Fluctuations) -> Trade:
             close_price, close_date = signal.to_price_date(position=position, candle=candle)
             return position.close(close_date=close_date, close_price=close_price)
 
-    last_candle = fluctuations_subset.last_candle()
+    last_candle = fluctuations_subset.get_candle_at(-1)
     return position.close(
         close_date=last_candle.close_time,
         close_price=Decimal(str(last_candle.close)),

--- a/ptahlmud/core/fluctuations.py
+++ b/ptahlmud/core/fluctuations.py
@@ -51,7 +51,7 @@ class Candle:
 
     @classmethod
     def from_series(cls, series: pd.Series) -> "Candle":
-        """Create a candle from a pandas Series."""
+        """Create a candle from a `pandas.Series`."""
         row_values = {column: series[column] for column in MANDATORY_COLUMNS} | {
             "high_time": series.get("high_time"),
             "low_time": series.get("low_time"),

--- a/ptahlmud/core/fluctuations.py
+++ b/ptahlmud/core/fluctuations.py
@@ -4,7 +4,7 @@ Market fluctuations are a time-series of financial candles.
 A candle is a financial object that represents the price variation of any asset during a period of time.
 Candles _must_ have an open, high, low and close price, an open and close time.
 
-The `Fluctuations` class is a wrapper around a pandas DataFrame.
+The `Fluctuations` class is also a wrapper around a pandas DataFrame.
 """
 
 from collections.abc import Iterable
@@ -13,7 +13,6 @@ from datetime import datetime
 from functools import cached_property
 
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, model_validator
 
 from ptahlmud.core.period import Period
 
@@ -60,45 +59,36 @@ class Candle:
         return cls(**row_values)
 
 
-class Fluctuations(BaseModel):
+def _validate_mandatory_columns(dataframe: pd.DataFrame) -> None:
+    """Check columns are present in the dataframe."""
+    missing_columns = set(MANDATORY_COLUMNS) - set(dataframe.columns)
+    if missing_columns:
+        columns_str = "', '".join(missing_columns)
+        raise ValueError(f"Missing mandatory columns column(s): '{columns_str}'.")
+
+
+class Fluctuations:
     """Interface for market fluctuations.
 
-    Args:
-        dataframe: pandas dataframe containing market data.
+    Attributes:
+        _dataframe: pandas dataframe containing market data.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    _dataframe: pd.DataFrame
 
-    dataframe: pd.DataFrame
+    def __init__(self, dataframe: pd.DataFrame):
+        _validate_mandatory_columns(dataframe)
 
-    @model_validator(mode="after")
-    def validate_mandatory_columns(self):
-        """Check columns are present in the dataframe."""
-        MANDATORY_COLUMNS = ["open_time", "close_time", "open", "high", "low", "close"]
-        for column in MANDATORY_COLUMNS:
-            if column not in self.columns:
-                raise ValueError(f"Missing column '{column}' in fluctuations.")
-        return self
+        dataframe = (
+            dataframe.sort_values(by="open_time", ascending=True)
+            .drop_duplicates(subset=["open_time"])
+            .reset_index(drop=True)
+        )
 
-    @model_validator(mode="after")
-    def validate_datetime_columns(self):
-        """Convert `open_time` and `close_time` to `datetime` if needed."""
+        self._dataframe = dataframe
+
         self.set("open_time", pd.to_datetime(self.get("open_time")))
         self.set("close_time", pd.to_datetime(self.get("close_time")))
-        return self
-
-    @model_validator(mode="after")
-    def validate_rows_order(self):
-        """Sort dataframe rows by their `open_time`."""
-        self.dataframe.sort_values(by="open_time", ascending=True).drop_duplicates(subset=["open_time"]).reset_index(
-            drop=True
-        )
-        return self
-
-    @classmethod
-    def from_pandas(cls, dataframe: pd.DataFrame) -> "Fluctuations":
-        """Create a fluctuations instance from a pandas DataFrame."""
-        return cls(dataframe=dataframe)
 
     @classmethod
     def empty(cls) -> "Fluctuations":
@@ -106,46 +96,51 @@ class Fluctuations(BaseModel):
         return cls(dataframe=pd.DataFrame(columns=MANDATORY_COLUMNS))
 
     @property
+    def dataframe(self):
+        """Return the underlying pandas DataFrame."""
+        return self._dataframe.copy()
+
+    @property
     def size(self) -> int:
         """Return the total number of candles."""
-        return len(self.dataframe)
+        return len(self._dataframe)
 
     @cached_property
     def columns(self):
         """Return the columns of the underlying pandas DataFrame."""
-        return self.dataframe.columns
+        return self._dataframe.columns
 
     @property
     def earliest_open_time(self) -> datetime:
         """Return the earliest open time."""
-        first_candle = self.dataframe.iloc[0]
-        return first_candle["open_time"].to_pydatetime()
+        first_candle = Candle.from_series(self._dataframe.iloc[0])
+        return first_candle.open_time
 
     @property
     def latest_close_time(self) -> datetime:
         """Return the latest close time."""
-        last_candle = self.dataframe.iloc[-1]
-        return last_candle["close_time"].to_pydatetime()
+        last_candle = Candle.from_series(self._dataframe.iloc[-1])
+        return last_candle.close_time
 
     @property
     def period(self) -> Period:
         """The time duration of the fluctuations as a `Period` object, assume every candle shares the same period."""
-        first_candle = self.dataframe.iloc[0]
+        first_candle = self._dataframe.iloc[0]
         candle_total_minutes = int((first_candle["close_time"] - first_candle["open_time"]).total_seconds()) // 60
         return Period(timeframe=str(candle_total_minutes) + "m")
 
     def get(self, name: str) -> pd.Series:
         """Return a column of the underlying pandas DataFrame."""
-        return self.dataframe[name]
+        return self._dataframe[name]
 
     def set(self, name: str, series: pd.Series) -> None:
         """Insert a column in the underlying pandas DataFrame."""
-        self.dataframe[name] = series
+        self._dataframe[name] = series
 
     def subset(self, from_date: datetime | None = None, to_date: datetime | None = None) -> "Fluctuations":
         """Select the candles between the given dates as a new instance of `Fluctuations`."""
         return Fluctuations(
-            dataframe=self.dataframe[
+            dataframe=self._dataframe[
                 (self.get("open_time") >= (from_date or self.earliest_open_time))
                 & (self.get("open_time") < (to_date or self.latest_close_time))
             ]
@@ -155,14 +150,14 @@ class Fluctuations(BaseModel):
         """Return the candle containing `date`."""
         if date > self.latest_close_time:
             raise ValueError("Date is after the latest close time.")
-        row = self.dataframe[self.dataframe["open_time"] >= date].iloc[0]
+        row = self._dataframe[self._dataframe["open_time"] >= date].iloc[0]
         return Candle.from_series(row)
 
     def last_candle(self) -> Candle:
         """Return the last candle."""
-        return Candle.from_series(self.dataframe.iloc[-1])
+        return Candle.from_series(self._dataframe.iloc[-1])
 
     def iter_candles(self) -> Iterable[Candle]:
         """Iterate over the candles in the fluctuations."""
-        for _, row in self.dataframe.iterrows():
+        for _, row in self._dataframe.iterrows():
             yield Candle.from_series(row)

--- a/ptahlmud/core/fluctuations.py
+++ b/ptahlmud/core/fluctuations.py
@@ -113,14 +113,12 @@ class Fluctuations:
     @property
     def earliest_open_time(self) -> datetime:
         """Return the earliest open time."""
-        first_candle = Candle.from_series(self._dataframe.iloc[0])
-        return first_candle.open_time
+        return self.get_candle_at(0).open_time
 
     @property
     def latest_close_time(self) -> datetime:
         """Return the latest close time."""
-        last_candle = Candle.from_series(self._dataframe.iloc[-1])
-        return last_candle.close_time
+        return self.get_candle_at(-1).close_time
 
     @property
     def period(self) -> Period:
@@ -146,16 +144,17 @@ class Fluctuations:
             ]
         )
 
-    def get_candle_at(self, date: datetime) -> Candle:
-        """Return the candle containing `date`."""
+    def get_candle_at(self, index: int) -> Candle:
+        """Return the i-th candle."""
+        row = self._dataframe.iloc[index]
+        return Candle.from_series(row)
+
+    def find_candle_containing(self, date: datetime) -> Candle:
+        """Return the only candle containing `date`."""
         if date > self.latest_close_time:
             raise ValueError("Date is after the latest close time.")
         row = self._dataframe[self._dataframe["open_time"] >= date].iloc[0]
         return Candle.from_series(row)
-
-    def last_candle(self) -> Candle:
-        """Return the last candle."""
-        return Candle.from_series(self._dataframe.iloc[-1])
 
     def iter_candles(self) -> Iterable[Candle]:
         """Iterate over the candles in the fluctuations."""

--- a/ptahlmud/core/fluctuations.py
+++ b/ptahlmud/core/fluctuations.py
@@ -123,8 +123,8 @@ class Fluctuations:
     @property
     def period(self) -> Period:
         """The time duration of the fluctuations as a `Period` object, assume every candle shares the same period."""
-        first_candle = self._dataframe.iloc[0]
-        candle_total_minutes = int((first_candle["close_time"] - first_candle["open_time"]).total_seconds()) // 60
+        first_candle = self.get_candle_at(0)
+        candle_total_minutes = int((first_candle.close_time - first_candle.open_time).total_seconds()) // 60
         return Period(timeframe=str(candle_total_minutes) + "m")
 
     def get(self, name: str) -> pd.Series:
@@ -153,8 +153,8 @@ class Fluctuations:
         """Return the only candle containing `date`."""
         if date > self.latest_close_time:
             raise ValueError("Date is after the latest close time.")
-        row = self._dataframe[self._dataframe["open_time"] >= date].iloc[0]
-        return Candle.from_series(row)
+        candle_index = int(self.get("open_time").ge(date).idxmin())
+        return self.get_candle_at(candle_index)
 
     def iter_candles(self) -> Iterable[Candle]:
         """Iterate over the candles in the fluctuations."""

--- a/ptahlmud/datastack/clients/binance_client.py
+++ b/ptahlmud/datastack/clients/binance_client.py
@@ -39,7 +39,7 @@ class BinanceClient(RemoteClient):
         )
 
         dataframe = _format_bars(historical_data, period=Period(timeframe=timeframe), end_date=end_date)
-        return Fluctuations.from_pandas(dataframe=dataframe)
+        return Fluctuations(dataframe=dataframe)
 
 
 def _format_bars(bars: list[tuple[float | int, ...]], period: Period, end_date: datetime) -> pd.DataFrame:

--- a/ptahlmud/datastack/fluctuations_repository.py
+++ b/ptahlmud/datastack/fluctuations_repository.py
@@ -101,7 +101,7 @@ class FluctuationsRepository:
 def _read_fluctuations(filepath: Path) -> Fluctuations:
     """Read fluctuations from a CSV file."""
     dataframe = pd.read_csv(filepath, sep=";")
-    return Fluctuations.from_pandas(dataframe=dataframe)
+    return Fluctuations(dataframe=dataframe)
 
 
 def _write_fluctuations(fluctuations: Fluctuations, filepath: Path) -> None:
@@ -112,4 +112,4 @@ def _write_fluctuations(fluctuations: Fluctuations, filepath: Path) -> None:
 def _merge_fluctuations(all_fluctuations: list[Fluctuations]) -> Fluctuations:
     """Merge multiple fluctuations into a single one."""
     merged_dataframes = pd.concat([fluctuations.dataframe for fluctuations in all_fluctuations]).reset_index(drop=True)
-    return Fluctuations.from_pandas(dataframe=merged_dataframes)
+    return Fluctuations(dataframe=merged_dataframes)

--- a/ptahlmud/datastack/fluctuations_service.py
+++ b/ptahlmud/datastack/fluctuations_service.py
@@ -297,10 +297,11 @@ def _convert_fluctuations_to_period(
     converted_fluctuations: Fluctuations = Fluctuations(dataframe=df_converted)
 
     # the last candle may be incomplete when the period is not a multiple of date range
-    last_candle = converted_fluctuations.last_candle()
+    last_candle = converted_fluctuations.get_candle_at(-1)
     if (last_candle.open_time + period.to_timedelta()) > last_candle.close_time:
-        df_converted = df_converted.iloc[:-1]
-    return Fluctuations(dataframe=df_converted)
+        return converted_fluctuations.subset(to_date=last_candle.open_time)
+
+    return converted_fluctuations
 
 
 def _merge_fluctuations(fluctuations_chunks: list[Fluctuations]) -> Fluctuations:

--- a/ptahlmud/datastack/fluctuations_service.py
+++ b/ptahlmud/datastack/fluctuations_service.py
@@ -294,13 +294,13 @@ def _convert_fluctuations_to_period(
         .reset_index(drop=True)
     )
 
-    converted_fluctuations: Fluctuations = Fluctuations.from_pandas(dataframe=df_converted)
+    converted_fluctuations: Fluctuations = Fluctuations(dataframe=df_converted)
 
     # the last candle may be incomplete when the period is not a multiple of date range
     last_candle = converted_fluctuations.last_candle()
     if (last_candle.open_time + period.to_timedelta()) > last_candle.close_time:
         df_converted = df_converted.iloc[:-1]
-    return Fluctuations.from_pandas(dataframe=df_converted)
+    return Fluctuations(dataframe=df_converted)
 
 
 def _merge_fluctuations(fluctuations_chunks: list[Fluctuations]) -> Fluctuations:
@@ -312,4 +312,4 @@ def _merge_fluctuations(fluctuations_chunks: list[Fluctuations]) -> Fluctuations
         .sort_values(by="open_time")
         .reset_index(drop=True)
     )
-    return Fluctuations.from_pandas(dataframe=merged_fluctuations)
+    return Fluctuations(dataframe=merged_fluctuations)

--- a/ptahlmud/testing/fluctuations.py
+++ b/ptahlmud/testing/fluctuations.py
@@ -58,4 +58,4 @@ def generate_fluctuations(
         "close": closes,
     }
     dataframe = pd.DataFrame(candles)
-    return Fluctuations.from_pandas(dataframe=dataframe)
+    return Fluctuations(dataframe=dataframe)

--- a/tests/backtesting/test_operations.py
+++ b/tests/backtesting/test_operations.py
@@ -147,7 +147,7 @@ def some_target(draw):
     some.sampled_from([Side.LONG, Side.SHORT]),
 )
 def test_calculate_trade_target_properties(fluctuations: Fluctuations, target: BarrierLevels, side: Side):
-    entry_candle = fluctuations.get_candle_at(fluctuations.earliest_open_time)
+    entry_candle = fluctuations.find_candle_containing(fluctuations.earliest_open_time)
     trade = calculate_trade(
         open_at=entry_candle.close_time,
         money_to_invest=Decimal(100),
@@ -181,7 +181,7 @@ def test_calculate_trade_target_properties(fluctuations: Fluctuations, target: B
     some.sampled_from([Side.LONG, Side.SHORT]),
 )
 def test_calculate_trade_temporal_properties(fluctuations: Fluctuations, target: BarrierLevels, side: Side):
-    entry_candle = fluctuations.get_candle_at(fluctuations.earliest_open_time)
+    entry_candle = fluctuations.find_candle_containing(fluctuations.earliest_open_time)
     trade = calculate_trade(
         open_at=entry_candle.close_time,
         money_to_invest=Decimal(100),
@@ -200,7 +200,7 @@ def test_calculate_trade_temporal_properties(fluctuations: Fluctuations, target:
     some.sampled_from([Side.LONG, Side.SHORT]),
 )
 def test_calculate_trade_return_properties(fluctuations: Fluctuations, target: BarrierLevels, side: Side):
-    entry_candle = fluctuations.get_candle_at(fluctuations.earliest_open_time)
+    entry_candle = fluctuations.find_candle_containing(fluctuations.earliest_open_time)
     trade = calculate_trade(
         open_at=entry_candle.close_time,
         money_to_invest=Decimal(100),

--- a/tests/backtesting/test_operations.py
+++ b/tests/backtesting/test_operations.py
@@ -147,7 +147,7 @@ def some_target(draw):
     some.sampled_from([Side.LONG, Side.SHORT]),
 )
 def test_calculate_trade_target_properties(fluctuations: Fluctuations, target: BarrierLevels, side: Side):
-    entry_candle = fluctuations.find_candle_containing(fluctuations.earliest_open_time)
+    entry_candle = fluctuations.get_candle_at(0)
     trade = calculate_trade(
         open_at=entry_candle.close_time,
         money_to_invest=Decimal(100),
@@ -181,7 +181,7 @@ def test_calculate_trade_target_properties(fluctuations: Fluctuations, target: B
     some.sampled_from([Side.LONG, Side.SHORT]),
 )
 def test_calculate_trade_temporal_properties(fluctuations: Fluctuations, target: BarrierLevels, side: Side):
-    entry_candle = fluctuations.find_candle_containing(fluctuations.earliest_open_time)
+    entry_candle = fluctuations.get_candle_at(0)
     trade = calculate_trade(
         open_at=entry_candle.close_time,
         money_to_invest=Decimal(100),
@@ -200,7 +200,7 @@ def test_calculate_trade_temporal_properties(fluctuations: Fluctuations, target:
     some.sampled_from([Side.LONG, Side.SHORT]),
 )
 def test_calculate_trade_return_properties(fluctuations: Fluctuations, target: BarrierLevels, side: Side):
-    entry_candle = fluctuations.find_candle_containing(fluctuations.earliest_open_time)
+    entry_candle = fluctuations.get_candle_at(0)
     trade = calculate_trade(
         open_at=entry_candle.close_time,
         money_to_invest=Decimal(100),


### PR DESCRIPTION
## Description

Nevermind #25, pydantic was a bit overkill for the `Fluctuations`. We only used validation helpers which led to an awkward pydantic-not-pydantic model.
* private dataframe not private
* pydantic serialization not used